### PR TITLE
Poprawki - forumla 3czlonowa i wielomiany Legendre

### DIFF
--- a/src/aproksymacja-funkcji.tex
+++ b/src/aproksymacja-funkcji.tex
@@ -116,13 +116,13 @@ $P_k = x^k + o(x^k)$ wyrażają się wzorem:
 $P_k(x) = (x + \beta_k) \cdot P_{k-1}(x) + \gamma_k P_{k-2}(x), k=1,\ldots$,
 $P_{-1}(x)=0$,
 $P_{0}(x)=1$,
-$\beta_k= \frac{(x P_{k-1}, P_k)}{\norm{P_{k-1}}^2}$,
+$\beta_k= \frac{(x P_{k-1}, P_{k-1})}{\norm{P_{k-1}}^2}$,
 $\gamma_k = \frac{(x P_{k-1}, P_{k-2})}{\norm{P_{k-2}}^2}$,
 % TODO: Fragmenty dowodu.
 
-% Wielomiany Lagrange'a
+% Wielomiany Legendre'a
 \entry
-Wielomiany Lagrange'a:
+Wielomiany Legendre'a:
 ort. w $L^2(-1,1)$ z wagą $\rho = 1$:
 $L_k(x) = \frac{2k-1}{k}xL_{k-1} - \frac{k-1}{k}L_{k-2}$,
 $\norm{L_k}^2=\frac{2}{2k+1}$;


### PR DESCRIPTION
Forumuła trójczłonowa poprawiona zgodnie ze wzorem z książki https://www.impan.pl/~szczep/AMM1/Kincaid.pdf ze str. 391